### PR TITLE
quote fix

### DIFF
--- a/components/quote.js
+++ b/components/quote.js
@@ -16,6 +16,7 @@ const Quote = ({ quote, source, sourceTitle }) =>
               <p class="project-body-quote">
                 <b>{quote}</b>
               </p>
+              <b><h1>”</h1></b>
               <footer class="blockquote-footer">
                 {source}
                 <cite title="Source Title">, {sourceTitle}</cite>

--- a/components/quote.js
+++ b/components/quote.js
@@ -16,7 +16,9 @@ const Quote = ({ quote, source, sourceTitle }) =>
               <p class="project-body-quote">
                 <b>{quote}</b>
               </p>
-              <b><h1>”</h1></b>
+              <b>
+                <h1> ” </h1>
+              </b>
               <footer class="blockquote-footer">
                 {source}
                 <cite title="Source Title">, {sourceTitle}</cite>


### PR DESCRIPTION
Currently quotes just have an open quote without being closed. This closes it as well. @tko22 did you forget to put it in, or was it because you think it looks better without just the quote? I thought it looked a little weird and Jackie also noticed it so we probably should close it, though maybe there's a way that looks better then what I did.

Before
![image](https://user-images.githubusercontent.com/18370633/63644133-39055680-c6a7-11e9-9e90-2325528b0fa3.png)

After
![image](https://user-images.githubusercontent.com/18370633/63644135-4ae6f980-c6a7-11e9-8047-c26c073394a6.png)
