### PR TITLE
Fix workflow runs on master

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           node-version: 12
 
+      - name: Install Surge
+        run: npm install -g surge
+
       - name: Install dependencies
         run: yarn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - "*"
+      - "!master"
+    tags:
+      - "!*"
 
 jobs:
   format:


### PR DESCRIPTION
Previously, both the CI and CD workflows were being run on `master`, instead of just the CD workflow. Additionally, Surge was not installed in the `deploy` action.