### PR TITLE
Statically-render project pages

### DIFF
--- a/pages/projects/[projectId].jsx
+++ b/pages/projects/[projectId].jsx
@@ -44,3 +44,24 @@ export default function Projects() {
     </div>
   );
 }
+
+// necessary to statically render all paths
+export function getStaticPaths() {
+  let projectIds = [];
+
+  projectData.forEach((semester) =>
+    semester.projects.forEach((project) => projectIds.push(project.id))
+  );
+
+  return {
+    paths: projectIds.map((projectId) => ({ params: { projectId } })),
+    fallback: false,
+  };
+}
+
+// necessary to statically render all paths
+export function getStaticProps() {
+  return {
+    props: {},
+  };
+}


### PR DESCRIPTION
As a result of switching the project routing from a query parameter to dynamic routes, `next export` no longer generated pages for each of the projects. This PR adds `getStaticPaths` and `getStaticProps` functions to the `projects/[projectId]` page to enable static rendering of all projet pages.